### PR TITLE
Fix potential leak

### DIFF
--- a/HTMLNode.m
+++ b/HTMLNode.m
@@ -29,6 +29,8 @@ void setAttributeNamed(xmlNode * node, const char * nameStr, const char * value)
 	char * newVal = (char *)malloc(strlen(value)+1);
 	memcpy (newVal, value, strlen(value)+1);
 
+	bool copyUsed = false;
+
 	for(xmlAttrPtr attr = node->properties; NULL != attr; attr = attr->next)
 	{
 		if (strcmp((char*)attr->name, nameStr) == 0)
@@ -37,12 +39,21 @@ void setAttributeNamed(xmlNode * node, const char * nameStr, const char * value)
 			{
 				free(child->content);
 				child->content = (xmlChar*)newVal;
+
+				if (!copyUsed)
+				{
+					copyUsed = true;
+				}
 				break;
 			}
 			break;
 		}
 	}
 	
+	if (!copyUsed)
+	{
+		free(newVal);
+	}
 	
 }
 


### PR DESCRIPTION
If the newVal is never set on a child's content entry, we will just end
up leaking that value at the end of the function. This should ensure that
if the value is used, even once, we do not free it at the end of the
function.

However, if it is not used at least once, we will free it at the end
of the function call.
