### PR TITLE
Rename this in order to push an unambiguous podspec

### DIFF
--- a/BRYHTMLParser.podspec
+++ b/BRYHTMLParser.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = 'ObjectiveCHTMLParser'
+  s.name         = 'BRYHTMLParser'
   s.version      = '1.0.2'
   s.summary      = 'An Objective-C wrapper around libxml for parsing HTML.'
   s.source       = { :git => 'https://github.com/irace/ObjectiveCHTMLParser.git', :tag => "#{s.version}" }


### PR DESCRIPTION
Give this a unique name in order to push it to the CocoaPods spec repo and have it be unambiguous.
