### PR TITLE
Addition of ending quote to silence documentation error in Xcode 9

### DIFF
--- a/BRYHTMLParser/HTMLNode.h
+++ b/BRYHTMLParser/HTMLNode.h
@@ -87,7 +87,7 @@ typedef NS_ENUM(unsigned int, HTMLNodeType) {
 /// Returns all children of class
 - (NSArray *)findChildrenOfClass:(NSString *)className;
 
-/// Finds a single child with a matching attribute. Set `allowPartial` to match partial matches, e.g. <img src="http://www.google.com> [findChildWithAttribute:@"src" matchingName:"google.com" allowPartial:TRUE]
+/// Finds a single child with a matching attribute. Set `allowPartial` to match partial matches, e.g. <img src="http://www.google.com"> [findChildWithAttribute:@"src" matchingName:"google.com" allowPartial:TRUE]
 - (id <HTMLNode>)findChildWithAttribute:(NSString *)attribute matchingName:(NSString *)className allowPartial:(BOOL)partial;
 
 /// Finds all children with a matching attribute


### PR DESCRIPTION
I don't see this warning when I open your project by itself in Xcode, but I see it in my project, so I'm making this PR to silence it. Xcode 9 is a stickler for html tags in comments apparently!

Thank you!


<img width="1507" alt="screen shot 2017-09-20 at 10 42 43 am" src="https://user-images.githubusercontent.com/978400/30650260-765c4b1a-9df0-11e7-9fc5-66ca39b58dbb.png">

